### PR TITLE
repair db loading in Sdv 1.3 beta compat

### DIFF
--- a/GiftTasteHelper/Framework/Models/GiftDatabaseModel.cs
+++ b/GiftTasteHelper/Framework/Models/GiftDatabaseModel.cs
@@ -57,9 +57,9 @@ namespace GiftTasteHelper.Framework
         /// <summary>
         /// Current DB version. This should be updated if there are schema changes that can't be handled by the serializer and a corresponding upgrade path should be made in GiftDatabase.cs.
         /// </summary>
-        public static readonly SemanticVersion CurrentVersion = new SemanticVersion("1.0");
+        public static readonly ISemanticVersion CurrentVersion = new SemanticVersion("1.0");
 
-        public SemanticVersion Version { get; set; } = new SemanticVersion("1.0");
+        public ISemanticVersion Version { get; set; } = new SemanticVersion("1.0");
         public Dictionary<string, CharacterTasteModel> Entries { get; set; } = new Dictionary<string, CharacterTasteModel>();
     }
 }

--- a/GiftTasteHelper/GiftTasteHelper.csproj
+++ b/GiftTasteHelper/GiftTasteHelper.csproj
@@ -37,6 +37,9 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="StardewModdingAPI.Toolkit.CoreInterfaces">
+      <HintPath>..\..\..\..\Spiele\Stardew Valley\StardewModdingAPI.Toolkit.CoreInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
@@ -76,16 +79,18 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <_TranslationFiles Include="$(ProjectDir)\i18n\*.json">
       <InProject>false</InProject>
     </_TranslationFiles>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0-beta-20180819\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Target Name="AfterBuild">
     <PropertyGroup>
@@ -97,11 +102,11 @@
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
     <Copy SourceFiles="@(_TranslationFiles)" DestinationFolder="$(ModPath)\i18n" Condition="Exists('$(ProjectDir)\i18n')" />
   </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0-beta-20180819\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0-beta-20180819\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0-beta-20180819\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0-beta-20180819\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/GiftTasteHelper/manifest.json
+++ b/GiftTasteHelper/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "GiftTasteHelper",
   "Author": "tstaples (aka catman)",
-  "Version": "2.8-beta",
+  "Version": "2.8.1-unofficial.1-LordHelmchen",
   "MinimumApiVersion": "2.6-beta",
   "Description": "Displays NPC gift tastes in a handy tooltip.",
   "UniqueID": "tstaples.GiftTasteHelper",

--- a/GiftTasteHelper/packages.config
+++ b/GiftTasteHelper/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180428" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0-beta-20180819" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
In contrast to my first pull request, this starts with the 1.3 branch, so it does not need to reinvent the wheel after changing SemanticVersion to ISemanticVersion.

Ignore the commit comment of 77c0953. This just fixes database loading and updates the ModBuildConfig used to 2.2.0-beta-20180819