### PR TITLE
Fix zoom bug on Social tab

### DIFF
--- a/GiftTasteHelper/Framework/Views/SocialPageGiftHelper.cs
+++ b/GiftTasteHelper/Framework/Views/SocialPageGiftHelper.cs
@@ -56,6 +56,7 @@ namespace GiftTasteHelper.Framework
             }
 
             SVector2 mousePos = new SVector2(e.NewPosition.ScreenPixels.X, e.NewPosition.ScreenPixels.Y);
+            mousePos = mousePos * Game1.options.zoomLevel;
             string hoveredNpc = this.SocialPage.GetCurrentlyHoveredNpc(mousePos);
             if (hoveredNpc == string.Empty)
             {


### PR DESCRIPTION
Lazy fix so that game zoom level is taken in to account on the social tab when hovering villagers, which fixes the complaints on the Nexus page.