### PR TITLE
Calculation of Page Bounds and Slot Height in Social Page fixed

### DIFF
--- a/GiftTasteHelper/Framework/Controllers/SocialPage.cs
+++ b/GiftTasteHelper/Framework/Controllers/SocialPage.cs
@@ -112,13 +112,19 @@ namespace GiftTasteHelper.Framework
 
         private float GetSlotHeight()
         {
-            return (this.FriendSlots[1].bounds.Y - this.FriendSlots[0].bounds.Y);
+            var currentSlot = this.GetSlotIndex();
+
+            var slotHeight = (this.FriendSlots[currentSlot+1].bounds.Y - this.FriendSlots[currentSlot].bounds.Y);
+
+            return slotHeight;
         }
 
         // Creates the bounds around all the slots on the screen within the page border.
         private Rectangle MakePageBounds()
         {
-            var rect = MakeSlotBounds(this.FriendSlots[0]);
+            var currentSlot = this.GetSlotIndex();
+
+            var rect = MakeSlotBounds(this.FriendSlots[currentSlot]);
             rect.Height = (int)this.SlotHeight * SDVSocialPage.slotsOnPage;
             return rect;
         }

--- a/GiftTasteHelper/GiftTasteHelper.csproj
+++ b/GiftTasteHelper/GiftTasteHelper.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
I think this bug was introduced with SDV 1.5.
When married or in coop, the social page does not display FriendSlot 0, but scrolls to the first non-player friend. Due to page bounds and slot height calculations being based fixed on FriendSlot 1 & 0, slot height could result in several hundreds pixel and / or page bounds beeing funky so no hover text was displayed.